### PR TITLE
Make `Gamepad.stick` consistent with the docs

### DIFF
--- a/docs/components/gamepad.md
+++ b/docs/components/gamepad.md
@@ -26,7 +26,7 @@ When `.query()`-ed returns whether the button is currently pressed.
 When `.query()`-ed returns a `Vector2` of the current position of the stick.
 
 * `stick` is the name of the (`left`, `right`) or an object
-  * the custom object looks like this: `{ xAxis: 0, yAxis: 1 }`
+  * the custom object looks like this: `{ label: 'Example stick', xAxis: 0, yAxis: 1 }`
 
 ---
 

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,16 +1,18 @@
 import typescript from 'rollup-plugin-typescript'
 
 const removeComments = () => ({
-  transform(source, id) {
+  transform(source) {
     return source.replace(/\/\*[^*]+\*\/\s+/g, '')
   }
 })
+
+const year = new Date().getFullYear()
 
 const addBanner = () => ({
   transformBundle(source) {
     return `/*!
  * Contro
- * (c) 2017 Niklas Higi
+ * (c) ${year} Niklas Higi
  * Released under the MIT License.
  */
 ` + source

--- a/src/inputs/gamepad.spec.ts
+++ b/src/inputs/gamepad.spec.ts
@@ -170,19 +170,19 @@ describe('The `Gamepad` class', () => {
       })
 
       it('returns a (0, 0) vector when initially queried', () => {
-        expect(gamepad.stick('left')).to.deep.equal(new Vector2())
+        expect(gamepad.stick('left').query()).to.deep.equal(new Vector2())
       })
 
       it('returns the correct vector when queried after change', () => {
         nav.gamepads[0].axes[0] = .56
         nav.gamepads[0].axes[1] = .31
-        expect(gamepad.stick('left')).to.deep.equal(new Vector2(.56, .31))
+        expect(gamepad.stick('left').query()).to.deep.equal(new Vector2(.56, .31))
       })
 
       it('also works with custom axis numbers', () => {
         nav.gamepads[0].axes[2] = .42
         nav.gamepads[0].axes[3] = .69
-        expect(gamepad.stick({ xAxis: 2, yAxis: 3 })).to.deep.equal(new Vector2(.42, .69))
+        expect(gamepad.stick({ label: '', xAxis: 2, yAxis: 3 }).query()).to.deep.equal(new Vector2(.42, .69))
       })
 
     })

--- a/src/inputs/gamepad.ts
+++ b/src/inputs/gamepad.ts
@@ -6,14 +6,15 @@ import { Vector2 } from '../utils/math'
 
 export interface GamepadStick {
 
+  label: string
   xAxis: number
   yAxis: number
 
 }
 
 const gamepadSticks: { [id: string]: GamepadStick } = {
-  left: { xAxis: 0, yAxis: 1 },
-  right: { xAxis: 2, yAxis: 3 },
+  left: { label: 'Left stick', xAxis: 0, yAxis: 1 },
+  right: { label: 'Right stick', xAxis: 2, yAxis: 3 },
 }
 
 export class Gamepad {
@@ -93,15 +94,25 @@ export class Gamepad {
     }
   }
 
-  public stick(stick: string | GamepadStick): Vector2 {
+  public stick(stick: string | GamepadStick): Control<Vector2> {
+    let gpStick: GamepadStick
     if (typeof stick === 'string') {
       if (stick in gamepadSticks) {
-        stick = gamepadSticks[stick]
+        gpStick = gamepadSticks[stick]
       } else {
         throw new Error(`Gamepad stick "${stick}" not found!`)
       }
+    } else {
+      gpStick = stick
     }
-    return new Vector2(this.gamepad.axes[stick.xAxis], this.gamepad.axes[stick.yAxis])
+
+    const {gamepad} = this
+    return {
+      label: gpStick.label,
+      query() {
+        return new Vector2(gamepad.axes[gpStick.xAxis], gamepad.axes[gpStick.yAxis])
+      },
+    }
   }
 
 }


### PR DESCRIPTION
This fixes the documentation inconsistency @quinton-ashley pointed out in #6. `Gamepad.stick` now returns a proper `Control` that has a `label` and can be `query`-ed.

*Closes #6*